### PR TITLE
Remove JsonConvert default serializing settings.

### DIFF
--- a/Source/Cogworks.UmbracoFlare.Core/Client/CloudflareApiClient.cs
+++ b/Source/Cogworks.UmbracoFlare.Core/Client/CloudflareApiClient.cs
@@ -47,7 +47,7 @@ namespace Cogworks.UmbracoFlare.Core.Client
             {
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(ApplicationConstants.ContentTypeApplicationJson));
                 var url = $"{ApplicationConstants.CloudflareApi.BaseUrl}{ApplicationConstants.CloudflareApi.UserEndpoint}";
-                
+
                 var request = new HttpRequestMessage
                 {
                     RequestUri = new Uri(url),
@@ -99,7 +99,8 @@ namespace Cogworks.UmbracoFlare.Core.Client
                         return response.Zones;
                     }
 
-                    _umbracoLoggingService.LogWarn<ICloudflareApiClient>($"Could not get the list of zones because of {response.Messages}");
+                    _umbracoLoggingService.LogWarn<ICloudflareApiClient>(GetLogMessage(response, "Could not get the list of zones. Message(s): "));
+
                     return Enumerable.Empty<Zone>();
                 }
                 catch (Exception e)
@@ -142,7 +143,7 @@ namespace Cogworks.UmbracoFlare.Core.Client
 
                     if (!response.Success)
                     {
-                        _umbracoLoggingService.LogWarn<ICloudflareApiClient>($"Something went wrong because of {response.Messages}");
+                        _umbracoLoggingService.LogWarn<ICloudflareApiClient>(GetLogMessage(response, "Something went wrong purging the cache. Message(s): "));
                         return false;
                     }
                 }
@@ -153,6 +154,22 @@ namespace Cogworks.UmbracoFlare.Core.Client
                 }
 
                 return true;
+            }
+        }
+
+        private string GetLogMessage(BasicCloudflareResponse response, string message)
+        {
+            if (response.Errors.Any())
+            {
+                return message + string.Join(", ", response.Errors.Select(e => $"{e.Message} - Code: {e.Code}"));
+            }
+            else if (response.Messages.Any())
+            {
+                return message + string.Join(", ", response.Messages);
+            }
+            else
+            {
+                return message + " No errormessage provided.";
             }
         }
 

--- a/Source/Cogworks.UmbracoFlare.Core/Components/UmbracoFlareEventsComponent.cs
+++ b/Source/Cogworks.UmbracoFlare.Core/Components/UmbracoFlareEventsComponent.cs
@@ -24,7 +24,7 @@ namespace Cogworks.UmbracoFlare.Core.Components
         private readonly IConfigurationService _configurationService;
         private readonly IUmbracoFlareDomainService _umbracoFlareDomainService;
         private readonly ICloudflareService _cloudflareService;
-        
+
         public UmbracoFlareEventsComponent(IImageCropperService imageCropperService, IUmbracoContextFactory umbracoContextFactory,
             IConfigurationService configurationService, IUmbracoFlareDomainService umbracoFlareDomainService, ICloudflareService cloudflareService)
         {
@@ -157,13 +157,27 @@ namespace Cogworks.UmbracoFlare.Core.Components
         {
             if (sender.TreeAlias != "content") { return; }
 
-            var menuItem = new MenuItem("purgeCache", "Purge Cloudflare Cache")
-            {
-                Icon = "umbracoflare-tiny"
-            };
+            MenuItem menuItem;
 
-            menuItem.LaunchDialogView("/App_Plugins/UmbracoFlare/dashboard/views/cogworks.umbracoflare.menu.html", "Purge Cloudflare Cache");
-            
+            if (e.NodeId == "-1") // if content root
+            {
+                menuItem = new MenuItem("purgeCache", "Purge Cloudflare Cache")
+                {
+                    Icon = "umbracoflare-tiny"
+                };
+
+                menuItem.LaunchDialogView("/App_Plugins/UmbracoFlare/dashboard/views/cogworks.umbracoflare.rootmenu.html", "Purge Cloudflare Cache");
+            }
+            else
+            {
+                menuItem = new MenuItem("purgeCache", "Purge Cloudflare Cache")
+                {
+                    Icon = "umbracoflare-tiny"
+                };
+
+                menuItem.LaunchDialogView("/App_Plugins/UmbracoFlare/dashboard/views/cogworks.umbracoflare.menu.html", "Purge Cloudflare Cache");
+            }
+
             e.Menu.Items.Insert(e.Menu.Items.Count - 1, menuItem);
         }
     }

--- a/Source/Cogworks.UmbracoFlare.Core/Components/UmbracoFlareStartupComponent.cs
+++ b/Source/Cogworks.UmbracoFlare.Core/Components/UmbracoFlareStartupComponent.cs
@@ -10,13 +10,6 @@ namespace Cogworks.UmbracoFlare.Core.Components
         public void Initialize()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
-            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                NullValueHandling = NullValueHandling.Ignore
-            };
         }
 
         public void Terminate()

--- a/Source/Cogworks.UmbracoFlare.Core/Extensions/EnumerableExtensions.cs
+++ b/Source/Cogworks.UmbracoFlare.Core/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Cogworks.UmbracoFlare.Core.Extensions
@@ -25,6 +27,56 @@ namespace Cogworks.UmbracoFlare.Core.Extensions
             {
                 self.Add(item);
             }
+        }
+
+        // Code found on Stackoverflow by casperOne Ref: https://stackoverflow.com/a/419058/150415
+        public static IEnumerable<IEnumerable<T>> Chunk<T>(this IEnumerable<T> source, int chunkSize)
+        {
+            // Validate parameters.
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (chunkSize <= 0) throw new ArgumentOutOfRangeException(nameof(chunkSize),
+                "The chunkSize parameter must be a positive value.");
+
+            // Call the internal implementation.
+            return source.ChunkInternal(chunkSize);
+        }
+
+        // Code found on Stackoverflow by casperOne Ref: https://stackoverflow.com/a/419058/150415
+        private static IEnumerable<IEnumerable<T>> ChunkInternal<T>(this IEnumerable<T> source, int chunkSize)
+        {
+            // Validate parameters.
+            Debug.Assert(source != null);
+            Debug.Assert(chunkSize > 0);
+
+            // Get the enumerator.  Dispose of when done.
+            using (IEnumerator<T> enumerator = source.GetEnumerator())
+                do
+                {
+                    // Move to the next element.  If there's nothing left
+                    // then get out.
+                    if (!enumerator.MoveNext()) yield break;
+
+                    // Return the chunked sequence.
+                    yield return ChunkSequence(enumerator, chunkSize);
+                } while (true);
+        }
+
+        // Code found on Stackoverflow by casperOne Ref: https://stackoverflow.com/a/419058/150415
+        private static IEnumerable<T> ChunkSequence<T>(IEnumerator<T> enumerator, int chunkSize)
+        {
+            // Validate parameters.
+            Debug.Assert(enumerator != null);
+            Debug.Assert(chunkSize > 0);
+
+            // The count.
+            int count = 0;
+
+            // There is at least one item.  Yield and then continue.
+            do
+            {
+                // Yield the item.
+                yield return enumerator.Current;
+            } while (++count < chunkSize && enumerator.MoveNext());
         }
     }
 }

--- a/Source/Cogworks.UmbracoFlare.Core/Services/CloudflareService.cs
+++ b/Source/Cogworks.UmbracoFlare.Core/Services/CloudflareService.cs
@@ -50,8 +50,17 @@ namespace Cogworks.UmbracoFlare.Core.Services
                 return new StatusWithMessage(false, $"Could not retrieve the zone from cloudflare with the domain of {currentDomain}");
             }
 
-            var apiResult = _cloudflareApiClient.PurgeCache(websiteZone.Id, urls, false);
+            var apiResult = false;
 
+            foreach (var chunk in urls.Chunk(30)) // Cloudflare has a limit of 30 urls in the API call
+            {
+
+                apiResult = _cloudflareApiClient.PurgeCache(websiteZone.Id, chunk, false);
+                if (!apiResult)
+                {
+                    break;
+                }
+            }
             return apiResult
                 ? new StatusWithMessage(true, "The values were purged successfully")
                 : new StatusWithMessage(false, "There was an error from the Cloudflare API. Please check the logs to see the issue.");

--- a/Source/Cogworks.UmbracoFlare.UI/App_Plugins/UmbracoFlare/dashboard/controllers/cogworks.umbracoflare.menu.controller.js
+++ b/Source/Cogworks.UmbracoFlare.UI/App_Plugins/UmbracoFlare/dashboard/controllers/cogworks.umbracoflare.menu.controller.js
@@ -24,27 +24,38 @@
             vm.menu.includeDescendants = !vm.menu.includeDescendants;
         }
 
+        var purgeSuccess = function (statusWithMessage) {
+            vm.menu.busy = false;
+
+            if (statusWithMessage.data.Success) {
+                vm.menu.error = false;
+                vm.menu.success = true;
+            } else {
+                vm.menu.error = true;
+                vm.menu.success = false;
+                vm.menu.errorMsg = statusWithMessage.data.Message === undefined ? "We are sorry, we could not clear the cache at this time." : statusWithMessage.data.Message;
+            }
+        }
+
+        var purgeError = function (error) {
+            vm.menu.busy = false;
+            vm.menu.success = false;
+            vm.menu.error = true;
+            vm.menu.errorMessage = "We are sorry, we could not clear the cache at this time.";
+        }
+
+        vm.menu.purgeEverything = function () {
+            vm.menu.busy = true;
+
+            cogworksUmbracoflareResources.purgeAll(vm.menu.currentDomain)
+                .then(purgeSuccess, purgeError);
+        }
+
         vm.menu.purge = function () {
             vm.menu.busy = true;
-            
+
             cogworksUmbracoflareResources.purgeCacheForNodeId($scope.currentNode.id, vm.menu.includeDescendants, vm.menu.currentDomain)
-                .then(function (statusWithMessage) {
-                    vm.menu.busy = false;
-                    
-                    if (statusWithMessage.data.Success) {
-                        vm.menu.error = false;
-                        vm.menu.success = true;
-                    } else {
-                        vm.menu.error = true;
-                        vm.menu.success = false;
-                        vm.menu.errorMsg = statusWithMessage.data.Message === undefined ? "We are sorry, we could not clear the cache at this time." : statusWithMessage.data.Message;
-                    }
-                }, function (error) {
-                    vm.menu.busy = false;
-                    vm.menu.success = false;
-                    vm.menu.error = true;
-                    vm.menu.errorMessage = "We are sorry, we could not clear the cache at this time.";
-                });
+                .then(purgeSuccess, purgeError);
         };
 
         vm.menu.closeDialog = function () {

--- a/Source/Cogworks.UmbracoFlare.UI/App_Plugins/UmbracoFlare/dashboard/views/cogworks.umbracoflare.rootmenu.html
+++ b/Source/Cogworks.UmbracoFlare.UI/App_Plugins/UmbracoFlare/dashboard/views/cogworks.umbracoflare.rootmenu.html
@@ -1,0 +1,28 @@
+﻿<div ng-controller="Cogworks.Umbracoflare.Menu.Controller as cogworksUmbracoflareMenuController" class="purge-menu">
+    <div class="umb-pane">
+        <div ng-hide="cogworksUmbracoflareMenuController.menu.success">
+            <p>
+                Are you sure you want to purge everything from the Cloudflare cache?
+            </p>
+            <br />
+        </div>
+
+        <div id="purge-menu-error" class="alert alert-error" ng-if="cogworksUmbracoflareRootMenuController.menu.error">
+            <h4>{{cogworksUmbracoflareRootMenuController.menu.errorMsg}}</h4>
+        </div>
+
+        <div id="purge-menu-success" class="alert alert-success" ng-if="cogworksUmbracoflareMenuController.menu.success">
+            <p>You have successfully cleared the cache for this node!</p>
+            <button class="btn btn-primary" ng-click="cogworksUmbracoflareMenuController.menu.closeDialog()">Ok</button>
+        </div>
+
+        <div ng-hide="cogworksUmbracoflareMenuController.menu.success" ng-class="{'-grey-out' : cogworksUmbracoflareMenuController.menu.busy}">
+            <a class="btn btn-link" ng-click="cogworksUmbracoflareMenuController.menu.closeDialog()">
+                <localize key="general_cancel">Cancel</localize>
+            </a>
+            <button class="btn btn-primary" ng-click="cogworksUmbracoflareMenuController.menu.purgeEverything()" ng-disabled="cogworksUmbracoflareMenuController.menu.busy">
+                Purge Cache
+            </button>
+        </div>
+    </div>
+</div>

--- a/Source/Cogworks.UmbracoFlare.UI/Cogworks.UmbracoFlare.UI.csproj
+++ b/Source/Cogworks.UmbracoFlare.UI/Cogworks.UmbracoFlare.UI.csproj
@@ -297,6 +297,7 @@
     <Content Include="App_Plugins\UmbracoFlare\dashboard\resources\cogworks.umbracoflare.resources.js" />
     <Content Include="App_Plugins\UmbracoFlare\dashboard\views\cogworks.umbracoflare.dashboard.html" />
     <Content Include="App_Plugins\UmbracoFlare\dashboard\views\cogworks.umbracoflare.inputadder.html" />
+    <Content Include="App_Plugins\UmbracoFlare\dashboard\views\cogworks.umbracoflare.rootmenu.html" />
     <Content Include="App_Plugins\UmbracoFlare\dashboard\views\cogworks.umbracoflare.menu.html" />
     <Content Include="config\grid.editors.config.js" />
     <Content Include="config\Lang\cs-CZ.user.xml" />


### PR DESCRIPTION
Setting JsonConvert.DefaultSettings to use CamelCase names causes the BlockList editor to corrupt its data on publish, ref #4 

I removed the code and everything seems to still work fine.