### PR TITLE
Remove JsonConvert default serializing settings.

### DIFF
--- a/Source/Cogworks.UmbracoFlare.Core/Components/UmbracoFlareStartupComponent.cs
+++ b/Source/Cogworks.UmbracoFlare.Core/Components/UmbracoFlareStartupComponent.cs
@@ -10,13 +10,6 @@ namespace Cogworks.UmbracoFlare.Core.Components
         public void Initialize()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
-            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                NullValueHandling = NullValueHandling.Ignore
-            };
         }
 
         public void Terminate()


### PR DESCRIPTION
Fixes #4 - Corruption of Block List elements on save.

As far as I can tell removing hte JsonConvert.DefaultSettings code has no effect on anything else.